### PR TITLE
fix: Preserve querystrings to /api/* from deployed app

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,5 @@
+# Redirect Cloudflare Pages traffic
+# https://developers.cloudflare.com/pages/configuration/redirects
+
+# Preserve all path structure and querystrings in requesting /api/*
+/api/* http://thehope.app/:splat 200

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,11 +27,15 @@ export default defineConfig({
     allowedHosts: ['localhost', '127.0.0.1'],
     proxy: {
       '/api': {
-        target: 'http://ticket.thehope.co',
         changeOrigin: true,
+
+        // NOTE: 本機開發時，正式環境的 API 網域
+        target: 'http://thehope.app',
+
+        // NOTE: 本機開發時，設定 headers 以解決後端設定的 CORS 問題
         headers: {
-          Origin: 'http://ticket.thehope.co',
-          Referer: 'http://ticket.thehope.co',
+          Origin: 'http://thehope.app',
+          Referer: 'http://thehope.app',
         },
       },
     },


### PR DESCRIPTION
As title. This also updates API proxy config to reflect current infra setup.