### PR TITLE
fix: Remove PAN_ONLY auth from Google Pay to match TapPay merchant setup

### DIFF
--- a/src/hooks/useTapPay.ts
+++ b/src/hooks/useTapPay.ts
@@ -37,7 +37,7 @@ export const useTapPay = (
 
       const googlePaySetting = {
         googleMerchantId: config.googleMerchantId,
-        allowedCardAuthMethods: ['PAN_ONLY', 'CRYPTOGRAM_3DS'],
+        allowedCardAuthMethods: ['CRYPTOGRAM_3DS'],
         merchantName: 'The Hope',
       };
       window.TPDirect.googlePay.setupGooglePay(googlePaySetting);


### PR DESCRIPTION
如題。因為目前的 TapPay 金流 vendor 好故事的 merchant 不支援非 3D 驗證，故需將 PAN_ONLY 選項關閉。